### PR TITLE
fix(config.toml): octo blog posts link fixed

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -67,7 +67,7 @@ pygmentsUseClasses = true
 [[menu.main]]
     name = "Blog"
     weight = 1
-    url  = "https://blog.octo.com/author/fabien-leite-lefa/"
+    url  = "https://blog.octo.com/author/fabien.leite/"
 [[menu.main]]
     name = "{}"
     weight = 1


### PR DESCRIPTION
The previous link showed blog posts by other users. 